### PR TITLE
Added check to prevent double clicks from skipping steps

### DIFF
--- a/src/jquery.pagewalkthrough.js
+++ b/src/jquery.pagewalkthrough.js
@@ -872,7 +872,7 @@
   /* Previous button clicks
    */
   $(document).on('click', '#jpwPrevious', function(ev) {
-    preventDoubleClick(ev, 'previous');
+    preventDoubleClick(ev, 'prev');
   });
 
   $(document).on(

--- a/src/jquery.pagewalkthrough.js
+++ b/src/jquery.pagewalkthrough.js
@@ -872,7 +872,7 @@
   /* Previous button clicks
    */
   $(document).on('click', '#jpwPrevious', function() {
-    preventDoubleClick(ev, 'next');
+    preventDoubleClick(ev, 'previous');
   });
 
   $(document).on(

--- a/src/jquery.pagewalkthrough.js
+++ b/src/jquery.pagewalkthrough.js
@@ -871,7 +871,7 @@
 
   /* Previous button clicks
    */
-  $(document).on('click', '#jpwPrevious', function() {
+  $(document).on('click', '#jpwPrevious', function(ev) {
     preventDoubleClick(ev, 'previous');
   });
 


### PR DESCRIPTION
We had several instances where a user could double click next and as a result skip multiple tour steps. This prevents the double click from occuring.