### PR TITLE
Feature skip all button implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ $.fn.pagewalkthrough.defaults = {
       // function which returns a boolean value
       show: true
     },
+    jpwSkipAll: {
+      i18n: 'Skip All &#9193;',
+      // Whether or not to show the button.  Can be a boolean value, or a
+      // function which returns a boolean value
+      show: function() {
+        return isFirstStep();
+      }
+    },
     jpwNext: {
       i18n: 'Next &rarr;',
       // Function which resolves to a boolean

--- a/src/css/jquery.pagewalkthrough.less
+++ b/src/css/jquery.pagewalkthrough.less
@@ -15,7 +15,7 @@
     font-weight: lighter;
 }
 
-#jpwClose, #jpwNext, #jpwPrevious, #jpwFinish {
+#jpwClose, #jpwSkipAll, #jpwNext, #jpwPrevious, #jpwFinish {
     .control();
 }
 

--- a/src/jquery.pagewalkthrough.js
+++ b/src/jquery.pagewalkthrough.js
@@ -414,6 +414,7 @@
       }
     }
 
+    showButton('jpwSkipAll');
     showButton('jpwPrevious');
     showButton('jpwNext');
     showButton('jpwFinish');
@@ -889,6 +890,10 @@
   /* Close and finish tour buttons clicks */
   $(document).on('click', '#jpwClose, #jpwFinish', methods.close);
 
+  /* Skip All to skip all tour steps
+   */
+  $(document).on('click', '#jpwSkipAll', methods.close);
+
   /* Next button clicks
    */
   $(document).on('click', '#jpwNext', function() {
@@ -1037,6 +1042,12 @@
         // Whether or not to show the button.  Can be a boolean value, or a
         // function which returns a boolean value
         show: true
+      },
+      jpwSkipAll: {
+        i18n: 'Skip All &#9193;',
+        show: function() {
+          return isFirstStep();
+        }
       },
       jpwNext: {
         i18n: 'Next &rarr;',


### PR DESCRIPTION
I have added skip all button, which will show up on first steps of Walkthrough.

Reason for implementing "Skip All" button: I was using this plugin with ionic 3 mobile apps. I don't need the close button because of close button position. at close button position in mobile, I need to place one highlighted tooltip. which is overlapping close button. that is why I added skip all button on the first step which allows the user to close Walkthrough at first step.