### PR TITLE
Fix: HTTPS for jQuery CDN url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
       </div>
     </div>
 
-    <script src="http://code.jquery.com/jquery-1.11.1.min.js" type="text/javascript"></script>
+    <script src="https://code.jquery.com/jquery-1.11.1.min.js" type="text/javascript"></script>
     <script src="bower_components/jquery-pagewalkthrough/dist/jquery.pagewalkthrough.js" type="text/javascript"></script>
     <script src="javascripts/main.js" type="text/javascript"></script>
   </body>


### PR DESCRIPTION
The demo page is currently broken when the page is accessed over https.

Mixed Content: The page at 'https://jwarby.github.io/jquery-pagewalkthrough/' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-1.11.1.min.js'. This request has been blocked; the content must be served over HTTPS.